### PR TITLE
adding toJson method to JWT for RFC7515 section 3.2 compliance 

### DIFF
--- a/src/JOSE/JWT.php
+++ b/src/JOSE/JWT.php
@@ -29,10 +29,20 @@ class JOSE_JWT {
             $this->compact($this->signature)
         ));
     }
+
     function __toString() {
         return $this->toString();
     }
 
+    function toJson() {
+        return json_encode(
+   			   array(
+			         "header" => $this->compact((object) $this->header),
+			         "payload" => $this->compact((object) $this->claims),
+			         "signature" => $this->compact($this->signature)
+				 ));
+    }
+    
     function sign($private_key_or_secret, $algorithm = 'HS256') {
         $jws = $this->toJWS();
         $jws->sign($private_key_or_secret, $algorithm);

--- a/src/JOSE/JWT.php
+++ b/src/JOSE/JWT.php
@@ -37,7 +37,7 @@ class JOSE_JWT {
     function toJson() {
         return json_encode(
    			   array(
-			         "header" => $this->compact((object) $this->header),
+			         "protected" => $this->compact((object) $this->header),
 			         "payload" => $this->compact((object) $this->claims),
 			         "signature" => $this->compact($this->signature)
 				 ));


### PR DESCRIPTION
Hi gree !

I propose this pull request so that your library is able to output json-serialized JWS instead of BASE-64 one, as per Section 3.2 of RFC7515 

https://tools.ietf.org/html/rfc7515#section-3.2

I'll use your library to build a PHP ACME Client API for Let's Encrypt https://letsencrypt.github.io/acme-spec/

(this patch may use any opensource/freesoftware license, MIT is fine to me)
