### PR TITLE
Adding Thumbprint as of RFC7638

### DIFF
--- a/src/JOSE/JWK.php
+++ b/src/JOSE/JWK.php
@@ -2,7 +2,7 @@
 
 use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
-use phpseclib\Crypt\Hash;
+use phpseclib\Crypt\Hash; 
 
 class JOSE_JWK {
     var $components = array();
@@ -42,25 +42,25 @@ class JOSE_JWK {
     static function encode($key, $extra_components = array()) {
         switch(get_class($key)) {
             case 'phpseclib\Crypt\RSA':
-	      $components = array(
-				  'kty' => 'RSA',
-				  'e' => JOSE_URLSafeBase64::encode($key->publicExponent->toBytes()),
-				  'n' => JOSE_URLSafeBase64::encode($key->modulus->toBytes())
-				  );
-	      if ($key->exponent != $key->publicExponent) {
-		$components = array_merge($components, array(
-							     'd' => JOSE_URLSafeBase64::encode($key->exponent->toBytes())
-							     ));
-	      }
-	      return new self(array_merge($components, $extra_components));
-	default:
-	  throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
+                $components = array(
+                    'kty' => 'RSA',
+                    'e' => JOSE_URLSafeBase64::encode($key->publicExponent->toBytes()),
+                    'n' => JOSE_URLSafeBase64::encode($key->modulus->toBytes())
+                );
+                if ($key->exponent != $key->publicExponent) {
+                    $components = array_merge($components, array(
+                        'd' => JOSE_URLSafeBase64::encode($key->exponent->toBytes())
+                    ));
+                }
+                return new self(array_merge($components, $extra_components));
+            default:
+                throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
         }
     }
 
     static function decode($components) {
-      $jwk = new self($components);
-      return $jwk->toKey();
+        $jwk = new self($components);
+        return $jwk->toKey();
     }
     
     /** 
@@ -70,19 +70,19 @@ class JOSE_JWK {
     function thumbprint() {
       $requiredcomp=array();
       switch ($this->components['kty']) {
-        case 'RSA':
-	  $requiredcomp=array("e"=>$this->components["e"],
-			      "kty"=>"RSA",
-			      "n"=>$this->components["n"]
-			      ); // ORDER MATTERS as required by RFC !
-	  break;
-        default:
-	  throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
+      case 'RSA':
+        $requiredcomp=array("e"=>$this->components["e"],
+			    "kty"=>"RSA",
+			    "n"=>$this->components["n"]
+			    ); // ORDER MATTERS as required by RFC !
+        break;
+      default:
+        throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
       }     
       $hash = new Hash('sha256');
       return JOSE_URLSafeBase64::encode(
 					$hash->hash( json_encode( $requiredcomp ) )
 					);
     }
-    
+
 }

--- a/src/JOSE/JWK.php
+++ b/src/JOSE/JWK.php
@@ -75,6 +75,7 @@ class JOSE_JWK {
 			      "kty"=>"RSA",
 			      "n"=>$this->components["n"]
 			      ); // ORDER MATTERS as required by RFC !
+	  break;
         default:
 	  throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
       }     

--- a/src/JOSE/JWK.php
+++ b/src/JOSE/JWK.php
@@ -2,6 +2,7 @@
 
 use phpseclib\Crypt\RSA;
 use phpseclib\Math\BigInteger;
+use phpseclib\Crypt\Hash;
 
 class JOSE_JWK {
     var $components = array();
@@ -41,24 +42,46 @@ class JOSE_JWK {
     static function encode($key, $extra_components = array()) {
         switch(get_class($key)) {
             case 'phpseclib\Crypt\RSA':
-                $components = array(
-                    'kty' => 'RSA',
-                    'e' => JOSE_URLSafeBase64::encode($key->publicExponent->toBytes()),
-                    'n' => JOSE_URLSafeBase64::encode($key->modulus->toBytes())
-                );
-                if ($key->exponent != $key->publicExponent) {
-                    $components = array_merge($components, array(
-                        'd' => JOSE_URLSafeBase64::encode($key->exponent->toBytes())
-                    ));
-                }
-                return new self(array_merge($components, $extra_components));
-            default:
-                throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
+	      $components = array(
+				  'kty' => 'RSA',
+				  'e' => JOSE_URLSafeBase64::encode($key->publicExponent->toBytes()),
+				  'n' => JOSE_URLSafeBase64::encode($key->modulus->toBytes())
+				  );
+	      if ($key->exponent != $key->publicExponent) {
+		$components = array_merge($components, array(
+							     'd' => JOSE_URLSafeBase64::encode($key->exponent->toBytes())
+							     ));
+	      }
+	      return new self(array_merge($components, $extra_components));
+	default:
+	  throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
         }
     }
 
     static function decode($components) {
-        $jwk = new self($components);
-        return $jwk->toKey();
+      $jwk = new self($components);
+      return $jwk->toKey();
     }
+    
+    /** 
+     * Returns the JWK Thumbprint of the Json Web Key
+     * see https://tools.ietf.org/html/rfc7638
+     */
+    function thumbprint() {
+      $requiredcomp=array();
+      switch ($this->components['kty']) {
+        case 'RSA':
+	  $requiredcomp=array("e"=>$this->components["e"],
+			      "kty"=>"RSA",
+			      "n"=>$this->components["n"]
+			      ); // ORDER MATTERS as required by RFC !
+        default:
+	  throw new JOSE_Exception_UnexpectedAlgorithm('Unknown key type');
+      }     
+      $hash = new Hash('sha256');
+      return JOSE_URLSafeBase64::encode(
+					$hash->hash( json_encode( $requiredcomp ) )
+					);
+    }
+    
 }

--- a/test/JOSE/JWK_Test.php
+++ b/test/JOSE/JWK_Test.php
@@ -91,4 +91,13 @@ class JOSE_JWK_Test extends JOSE_TestCase {
         $this->setExpectedException('JOSE_Exception_UnexpectedAlgorithm');
         JOSE_JWK::decode($components);
     }
+
+    function testThumbprint() {
+        $rsa = new RSA();
+        $rsa->loadKey($this->rsa_keys['public']);
+        $jwk = JOSE_JWK::encode($rsa);
+        $this->assertInstanceOf('JOSE_JWK', $jwk);
+        $this->assertEquals('nuBTimkcSt_AuEsD8Yv3l8CoGV31bu_3gsRDGN1iVKA', $jwk->thumbprint() );
+    }
+
 }


### PR DESCRIPTION
Hi Gree.

I'm using your JOSE Library for the LetsEncrypt PHP client. Thanks a lot ! 

I have a patch I had to create since your library was missing JWK Thumbprint (sha256 fingerprint of keys)

This pull request contains a new method named thumbprint() that returns the thumbprint of the key, and a unit test for it.

reference : https://tools.ietf.org/html/rfc7638